### PR TITLE
Fix bug preventing `carrot` from running in a container

### DIFF
--- a/carrot/cdm/model.py
+++ b/carrot/cdm/model.py
@@ -185,12 +185,19 @@ class CommonDataModel(Logger):
         self.logs = {
             'meta':{
                 'version': carrot_version,
-                'created_by': getpass.getuser(),
+                'created_by': self._get_user(),
                 'created_at': strftime("%Y-%m-%dT%H%M%S", gmtime()),
                 'dataset':name,
                 'total_data_processed':{}
             }
         }
+
+    def _get_user(self):
+        try:
+            user = getpass.getuser()
+            return user
+        except (OSError, KeyError):
+            return None
 
     def _load_inputs(self,inputs):
         for fname in inputs.keys():


### PR DESCRIPTION
## Description
Add a method to `CommonDataModel` in `carrot/cdm/model.py` which ignores when `getpass.getuser` can't find the logged in user when running in a docker container.

## Rationale
When running `carrot run map` in a docker container, the following error occurs:
```
Traceback (most recent call last):
  File "/usr/local/bin/carrot", line 33, in <module>
    sys.exit(load_entry_point('carrot-cdm', 'console_scripts', 'carrot')())
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/carrot-cdm/carrot/cli/subcommands/run.py", line 573, in map
    cdm = carrot.cdm.CommonDataModel(name=name,
  File "/carrot-cdm/carrot/cdm/model.py", line 188, in __init__
    'created_by': getpass.getuser(),
  File "/usr/local/lib/python3.10/getpass.py", line 169, in getuser
    return pwd.getpwuid(os.getuid())[0]
KeyError: 'getpwuid(): uid not found: 502'
```
This happens because `getpass.getuser` searches for various environment variables and falls back on `/etc/passwd` to get the username. In containers, none of these things are set, resulting in the error above.

This fix was implemented so a portable containerised workflow can be implemented in tools like [cwltool](https://www.commonwl.org/v1.2/) or [nextflow](https://www.nextflow.io/).